### PR TITLE
Scryfall Import Adjustments

### DIFF
--- a/app/Console/Commands/ImportScryfall.php
+++ b/app/Console/Commands/ImportScryfall.php
@@ -11,7 +11,7 @@ use App\Models\ProductPrice;
 use App\Models\Release;
 use Brick\Money\Money;
 use Illuminate\Console\Command;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Http;
 use JsonMachine\Items;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -22,7 +22,7 @@ use function Laravel\Prompts\info;
 class ImportScryfall extends Command
 {
 
-    public \Illuminate\Database\Eloquent\Collection $known_releases;
+    public Collection $known_releases;
 
     public function handle()
     {

--- a/database/migrations/2024_06_18_115225_add_index_to_products.php
+++ b/database/migrations/2024_06_18_115225_add_index_to_products.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+
+	public function up(): void
+	{
+		Schema::table('products', function(Blueprint $table) {
+			$table->string('external_id')->nullable()->change();
+            $table->index([
+                'external_id',
+                'provider',
+                'franchise'
+            ]);
+		});
+	}
+
+
+	public function down(): void
+	{
+
+        Schema::table('products', function(Blueprint $table) {
+            $table->dropIndex([
+                'external_id',
+                'provider',
+                'franchise'
+            ]);
+		});
+
+        Schema::table('products', function(Blueprint $table) {
+            $table->text('external_id')->nullable()->change();
+		});
+	}
+};

--- a/tests/Data/default_cards.json
+++ b/tests/Data/default_cards.json
@@ -1,0 +1,45 @@
+[
+    {
+        "object": "card",
+        "id": "aaa12345",
+        "name": "Black Lotus",
+        "lang": "en",
+        "set_id": "xxx1234",
+        "set_name": "Limited Edition Alpha",
+        "set": "lea",
+        "oracle_text": "You win.",
+        "prices": {
+            "usd": "0.50",
+            "usd_foil": "1.00",
+            "usd_etched": "1.50"
+        }
+    },{
+        "object": "card",
+        "id": "bbb12345",
+        "name": "Mox Emerald",
+        "lang": "en",
+        "set_id": "xxx1234",
+        "set_name": "Limited Edition Alpha",
+        "set": "lea",
+        "oracle_text": "Good card.",
+        "prices": {
+            "usd": "2.00",
+            "usd_foil": "3.00",
+            "usd_etched": "4.50"
+        }
+    },{
+        "object": "card",
+        "id": "ccc12345",
+        "name": "Ravenous Baloth",
+        "lang": "ja",
+        "set_id": "zzz1234",
+        "set_name": "Onslaught",
+        "set": "m13",
+        "oracle_text": "",
+        "prices": {
+            "usd": "3.00",
+            "usd_foil": "4.00",
+            "usd_etched": "5.50"
+        }
+    }
+]

--- a/tests/Data/unique_artwork.json
+++ b/tests/Data/unique_artwork.json
@@ -1,0 +1,17 @@
+[
+    {
+        "object": "card",
+        "id": "ggg12345",
+        "name": "Black Lotus",
+        "lang": "en",
+        "set_id": "yyyy1234",
+        "set_name": "Limited Edition Beta",
+        "set": "leb",
+        "oracle_text": "You win.",
+        "prices": {
+            "usd": "500",
+            "usd_foil": "1000",
+            "usd_etched": "1500"
+        }
+    }
+]

--- a/tests/Feature/Console/Commands/ImportScryfallTest.php
+++ b/tests/Feature/Console/Commands/ImportScryfallTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Console\Commands\ImportScryfall;
+use App\Enums\Finishes;
+use App\Enums\Franchises;
+use App\Enums\Providers;
+use App\Models\Product;
+use App\Models\Release;
+use Illuminate\Support\Facades\Http;
+use function Pest\testDirectory;
+
+it('can import scryfall products', function () {
+
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'https://api.scryfall.com/bulk-data' => Http::response([
+           'data' => [
+               [
+                   'type' => 'default_cards',
+                   'download_uri' => testDirectory('Data/default_cards.json')
+               ],[
+                   'type' => 'unique_artwork',
+                   'download_uri' => testDirectory('Data/unique_artwork.json')
+               ]
+           ]
+        ])
+    ]);
+
+    $this->artisan(ImportScryfall::class);
+
+    $release = Release::where('external_id', '=', 'xxx1234')
+        ->where('name', '=', 'Limited Edition Alpha')
+        ->where('code', '=', 'lea')
+        ->first();
+    $this->assertNotNull($release);
+
+    $product = Product::where('provider', '=', Providers::SCRYFALL)
+        ->where('franchise', '=', Franchises::MAGIC)
+        ->where('external_id', '=', 'aaa12345')
+        ->with(['prices'])
+        ->first();
+    $this->assertEquals($release->id, $product->release_id);
+    $this->assertEquals('en', $product->language);
+    $this->assertEquals('Black Lotus', $product->name);
+    $this->assertEquals('You win.', $product->description);
+
+    $this->assertEquals(50, $product->prices->firstWhere('finish', '=', Finishes::NONFOIL)->price);
+    $this->assertEquals(1_00, $product->prices->firstWhere('finish', '=', Finishes::FOIL)->price);
+    $this->assertEquals(1_50, $product->prices->firstWhere('finish', '=', Finishes::ETCHED)->price);
+
+    $release = Release::where('external_id', '=', 'yyyy1234')
+        ->where('name', '=', 'Limited Edition Beta')
+        ->where('code', '=', 'leb')
+        ->first();
+    $this->assertNotNull($release);
+
+    $product = Product::where('provider', '=', Providers::SCRYFALL)
+        ->where('franchise', '=', Franchises::MAGIC)
+        ->where('external_id', '=', 'ggg12345')
+        ->with(['prices'])
+        ->first();
+    $this->assertEquals($release->id, $product->release_id);
+    $this->assertEquals('en', $product->language);
+    $this->assertEquals('Black Lotus', $product->name);
+    $this->assertEquals('You win.', $product->description);
+
+    $this->assertEquals(500_00, $product->prices->firstWhere('finish', '=', Finishes::NONFOIL)->price);
+    $this->assertEquals(1000_00, $product->prices->firstWhere('finish', '=', Finishes::FOIL)->price);
+    $this->assertEquals(1500_00, $product->prices->firstWhere('finish', '=', Finishes::ETCHED)->price);
+
+});
+
+it('can update existing product prices', function () {
+
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'https://api.scryfall.com/bulk-data' => Http::response([
+           'data' => [
+               [
+                   'type' => 'default_cards',
+                   'download_uri' => testDirectory('Data/default_cards.json')
+               ],[
+                   'type' => 'unique_artwork',
+                   'download_uri' => testDirectory('Data/unique_artwork.json')
+               ]
+           ]
+        ])
+    ]);
+
+    $product = Product::factory()->create([
+       'external_id' => 'aaa12345',
+       'provider' => Providers::SCRYFALL,
+       'franchise' => Franchises::MAGIC,
+    ]);
+
+    $this->artisan(ImportScryfall::class);
+
+    $product->load('prices');
+
+    $this->assertEquals(50, $product->prices->firstWhere('finish', '=', Finishes::NONFOIL)->price);
+    $this->assertEquals(1_00, $product->prices->firstWhere('finish', '=', Finishes::FOIL)->price);
+    $this->assertEquals(1_50, $product->prices->firstWhere('finish', '=', Finishes::ETCHED)->price);
+
+});
+
+it('can reuse known releases', function () {
+
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'https://api.scryfall.com/bulk-data' => Http::response([
+           'data' => [
+               [
+                   'type' => 'default_cards',
+                   'download_uri' => testDirectory('Data/default_cards.json')
+               ],[
+                   'type' => 'unique_artwork',
+                   'download_uri' => testDirectory('Data/unique_artwork.json')
+               ]
+           ]
+        ])
+    ]);
+
+    $release = Release::factory()->create([
+       'external_id' => 'xxx1234',
+       'code' => 'lea',
+       'name' => 'Limited Edition Alpha',
+    ]);
+
+    $this->artisan(ImportScryfall::class);
+
+    $product = Product::where('external_id', '=', 'aaa12345')->first();
+    $this->assertEquals($release->id, $product->release_id);
+
+});
+
+it('will ignore nonenglish cards', function () {
+
+    Http::preventStrayRequests();
+
+    Http::fake([
+        'https://api.scryfall.com/bulk-data' => Http::response([
+           'data' => [
+               [
+                   'type' => 'default_cards',
+                   'download_uri' => testDirectory('Data/default_cards.json')
+               ],[
+                   'type' => 'unique_artwork',
+                   'download_uri' => testDirectory('Data/unique_artwork.json')
+               ]
+           ]
+        ])
+    ]);
+
+    $this->artisan(ImportScryfall::class);
+
+    $this->assertNull(Product::where('external_id', '=', 'ccc12345')->first());
+    $this->assertNull(Release::where('external_id', '=', 'zzz1234')->first());
+
+});


### PR DESCRIPTION
Some suggestions in the scryfall import command to reduce repetition and reuse known releases (avoiding some N+1 issues)

A database adjustment to make external_id a varchar and add a composite index.  This could potentially be a unique composite index.

Added some tests to verify the import works as expected.  Mocking JsonMachine\Items::fromFile() would have been nice, but it was simpler to create data fixtures to start.